### PR TITLE
Fix: Moved to username/password from X509 cert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dist
 .yarn/install-state.gz
 .pnp.*
 X509-cert-5618187502851416559.pem
+.history

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ const mongoose = require('mongoose'); // Added for Mongoose
 const { MongoClient } = require('mongodb');
 const authRoutes = require("./routes/authRoutes");
 
-if (!process.env.MONGODB_URI || !process.env.SESSION_SECRET || !process.env.CREDENTIALS) {
+if (!process.env.MONGODB_URI || !process.env.SESSION_SECRET) {
   console.error("Error: config environment variables not set. Please create/edit .env configuration file.");
   process.exit(-1);
 }
@@ -28,16 +28,13 @@ let dbClient;
 // New MongoDB connection using MongoClient for sessions
 async function connectDB() {
   try {
-    dbClient = new MongoClient(uri, {
-      tlsCAFile: process.env.CREDENTIALS
-    });
+    dbClient = new MongoClient(uri);
 
     await dbClient.connect();
     console.log("Database connected successfully using MongoClient for sessions");
 
     // Connect to MongoDB using Mongoose
     await mongoose.connect(uri, {
-      tlsCAFile: process.env.CREDENTIALS,
       useNewUrlParser: true,
       useUnifiedTopology: true,
     });


### PR DESCRIPTION
fixes #1 

Created a new user for the Cluster/App in Atlas. Updated the connect string passed in via the environment to use the username and password (note that the password is URL encoded with the occurrence of `%40` representing `@`).

Updated the checks on the availability of env vars and removed the TLS cruft from the creation of the MongoClient and the Mongoose client.